### PR TITLE
fix: Added CoreRendering to module.txt

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -7,6 +7,7 @@
     "dependencies" : [
         {"id": "BiomesAPI", "minVersion": "4.0.0"},
         {"id": "CoreAssets", "minVersion": "2.0.0"},
+        {"id": "CoreRendering", "minVersion": "1.0.0" },
         {"id": "CoreWorlds", "minVersion": "1.0.0"},
         {"id": "PlantPack", "minVersion": "1.0.0"}
     ],


### PR DESCRIPTION
CoreRendering should be a dependency for ParadIce because without it when you try to great a world with the minimal template it can't make a world because it doesn't have CoreRendering.  With CoreRendering added it the gameplay template should work without having to go into the advanced section.